### PR TITLE
Update mailbox.c

### DIFF
--- a/mailbox.c
+++ b/mailbox.c
@@ -35,6 +35,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <sys/mman.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 
 #include "mailbox.h"
 


### PR DESCRIPTION
Added:

```
#include <sys/sysmacros.h>
```

I found this issue somewhere else where it was described that:
```
Glibc removes sys/sysmacros.h which defines makedev from sys/types.h since v2.28. [Commit ID: e16deca62e16f]

And then glibc suggestions us to include <sys/sysmacros.h>`directly if code needs it.
```

Without this fix running 'make' on newer system fails as such:

```
root@pi-dx:~/github/pi-rc# make
cc -Wall -Wextra -Wshadow -Wswitch-enum -Wswitch-default -Wmissing-prototypes -Wmissing-declarations -Wstrict-prototypes -DRASPI=2   -c -o pi_pcm.o pi_pcm.c
cc -Wall -Wextra -Wshadow -Wswitch-enum -Wswitch-default -Wmissing-prototypes -Wmissing-declarations -Wstrict-prototypes -DRASPI=2   -c -o mailbox.o mailbox.c
mailbox.c: In function ‘mbox_open’:
mailbox.c:258:52: warning: implicit declaration of function ‘makedev’ [-Wimplicit-function-declaration]
     if(mknod(LOCAL_DEVICE_FILE_NAME, S_IFCHR|0600, makedev(MAJOR_NUM_A, 0)) >= 0 &&
                                                    ^~~~~~~
cc   pi_pcm.o mailbox.o  -lm -o pi_pcm
/usr/bin/ld: mailbox.o: in function `mbox_open':
mailbox.c:(.text+0xc0c): undefined reference to `makedev'
/usr/bin/ld: mailbox.c:(.text+0xc74): undefined reference to `makedev'
collect2: error: ld returned 1 exit status
make: *** [<builtin>: pi_pcm] Error 1
```